### PR TITLE
Support multiple components with the same name (fix for #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ addParameters({
     //completely hide a dependency/dependents block if it has no elements
     //by default this is false
     hideEmpty: true,
+
+    //custom match function to find matching component in case duplicate 
+    //component names. chooses first match if not configured
+    match: (matchingComponents, storyFilename) => matchingComponents?.[0][0]
   }
 });
 ```

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -41,14 +41,16 @@ export const getComponentName = (component?: ComponentType | string): string | u
   return component.name;
 }  
 
-export const findComponentDependencies: ComponentDependenciesFunction = memoize(20)((map, component) => {
+export const findComponentDependencies: ComponentDependenciesFunction = memoize(20)((map, component, parameters) => {
+  const storyFilename = parameters.fileName;
+  const match = parameters.dependencies.match ?? ((m) => m?.[0][0])
   const { mapper } = map;
   if (mapper && component) {
     const componentName = getComponentName(component);
     // console.log('componentName', component, Object.keys(mapper).filter(key => mapper[key].id).map(key => mapper[key]));
     if (componentName) {
       
-      const key = Object.keys(mapper).find(key => mapper[key].id === componentName || mapper[key].name === componentName);
+      const key = match(Object.entries(mapper).filter(([key]) => mapper[key].id === componentName || mapper[key].name === componentName), storyFilename);
       if (key) {
         let module = mapper[key];
         module.key = key;
@@ -145,7 +147,7 @@ export const getDependenciesProps = (
   }
   
   const noDepError = `No ${dependents ? 'dependents' : 'dependencies'} found for this component`;
-  const module: IDependency = findComponentDependencies(map, target);
+  const module: IDependency = findComponentDependencies(map, target, parameters);
   if (!module) {
     return { error: noDepError, hideEmpty: dependenciesParam.hideEmpty,}
   }


### PR DESCRIPTION
This PR attempts to fix issue https://github.com/atanasster/storybook-addon-deps/issues/13

The idea is to make it possible for the user to configure a callback function that determines which component is to be considered a match in case multiple components match by name. By default, a function that chooses the first in the list is provided - this should ensure full backwards compatibility.

As an example, I use a `match` function that tries to choose the right component based on the `contextPath` of the component and the story filename, assuming that the closer the story and the component is in the file structure the more likely it is they are related. I use a function like

```
addParameters({
  docs: { page: DocsPage },
  dependencies: {
    match: (matchingComponents, storyFilename) => { 
      if (matchingComponents.length < 2) return matchingComponents?.[0][0];
      
      return matchingComponents.sort(([,e], [,f]) => {
        const l1 = findLongestCommonSubstring(e.contextPath, storyFilename).length;
        const l2 = findLongestCommonSubstring(f.contextPath, storyFilename).length;
        if (l1 > l2) return -1;
        if (l1 < l2) return 1;
        return 0;
      })[0][0];
    }
  }
})
```